### PR TITLE
Better animate and render props

### DIFF
--- a/src/Animate/Animate.js
+++ b/src/Animate/Animate.js
@@ -43,7 +43,7 @@ type Props = {
 class Animate extends Component {
   static defaultProps = {
     show: true,
-    children: () => null
+    children: () => null,
   };
 
   state = typeof this.props.start === 'function' ? this.props.start() : this.props.start;

--- a/src/Animate/Animate.js
+++ b/src/Animate/Animate.js
@@ -33,7 +33,7 @@ type Props = {
   /**
    * A function that renders the node. The function is passed the state.
    */
-  children?: (state: {}) => {},
+  children: (state: {}) => {},
   /**
    * A function that renders the node. The function is passed the state.
    */
@@ -43,6 +43,7 @@ type Props = {
 class Animate extends Component {
   static defaultProps = {
     show: true,
+    children: () => null
   };
 
   state = typeof this.props.start === 'function' ? this.props.start() : this.props.start;

--- a/src/Animate/Animate.js
+++ b/src/Animate/Animate.js
@@ -11,27 +11,39 @@ type Props = {
   /**
    * Boolean value that determines if the child should be rendered or not.
    */
-  show: bool,
+  show: boolean,
   /**
-  * An object or function that returns an obejct to be used as the starting state.
-  */
-  start: {} | () => {},
+   * An object or function that returns an obejct to be used as the starting state.
+   */
+  start: {} | (() => {}),
   /**
    * An object, array of objects, or function that returns an object or array of objects describing how the state should transform on enter.
    */
-  enter?: {} | Array<{}> | () => {},
+  enter?: {} | Array<{}> | (() => {}),
   /**
    * An object, array of objects, or function that returns an object or array of objects describing how the state should transform on update. ***Note:*** although not required, in most cases it make sense to specify an update prop to handle interrupted enter and leave transitions.
    */
-  update?: {} | Array<{}> | () => {},
+  update?: {} | Array<{}> | (() => {}),
   /**
    * An object, array of objects, or function that returns an object or array of objects describing how the state should transform on leave.
    */
-  leave?: {} | Array<{}> | () => {},
+  leave?: {} | Array<{}> | (() => {}),
   /**
-   * A function that renders the node.  The function is passed the data and state.
+   * An optional default timing object for any interpolations happening in this component.
    */
-  children: (state: {}) => {},
+  timing?: Object,
+  /**
+   * A function that renders the node. The function is passed the state.
+   */
+  children?: (state: {}) => {},
+  /**
+   * A function that renders the node. The function is passed the state.
+   */
+  render?: (state: {}) => {},
+  /**
+   * A function that renders the node. The function is passed the state.
+   */
+  Component?: React.Component,
 };
 
 class Animate extends Component {
@@ -49,6 +61,7 @@ class Animate extends Component {
       children,
       render,
       Component: Comp,
+      timing,
       ...rest
     } = this.props;
 
@@ -60,6 +73,7 @@ class Animate extends Component {
         enter={typeof enter === 'function' ? enter : () => enter}
         update={typeof update === 'function' ? update : () => update}
         leave={typeof leave === 'function' ? leave : () => leave}
+        timing={timing}
       >
         {(inters) => {
           if (!inters.length) {

--- a/src/Animate/Animate.js
+++ b/src/Animate/Animate.js
@@ -55,15 +55,15 @@ class Animate extends Component {
   }
 
   componentDidMount() {
-    const { enter, show } = this.props;
+    const { enter, show, timing } = this.props;
 
     if (enter && show === true) {
-      transition.call(this, typeof enter === 'function' ? enter() : enter);
+      transition.call(this, typeof enter === 'function' ? enter() : enter, timing);
     }
   }
 
   componentWillReceiveProps(next) {
-    const { show, start, enter, update, leave } = next;
+    const { show, start, enter, update, leave, timing } = next;
 
     if (this.props.show === false && this.renderNull === true && show === true) {
       this.renderNull = false;
@@ -72,13 +72,13 @@ class Animate extends Component {
         () => (typeof start === 'function' ? start() : start),
         () => {
           if (enter) {
-            transition.call(this, typeof enter === 'function' ? enter() : enter);
+            transition.call(this, typeof enter === 'function' ? enter() : enter, timing);
           }
         },
       );
     } else if (this.props.show === true && show === false) {
       if (leave) {
-        transition.call(this, typeof leave === 'function' ? leave() : leave);
+        transition.call(this, typeof leave === 'function' ? leave() : leave, timing);
         this.interval = interval(this.checkTransitionStatus);
       } else {
         this.renderNull = true;
@@ -89,7 +89,7 @@ class Animate extends Component {
         this.interval.stop();
       }
 
-      transition.call(this, typeof update === 'function' ? update() : update);
+      transition.call(this, typeof update === 'function' ? update() : update, timing);
     }
   }
 

--- a/src/Animate/Animate.js
+++ b/src/Animate/Animate.js
@@ -55,11 +55,11 @@ class Animate extends Component {
     return (
       <NodeGroup
         data={show ? [true] : []}
-        keyAccessor={(d, i) => i}
-        start={() => start}
-        enter={() => enter}
-        update={() => update}
-        leave={() => leave}
+        keyAccessor={(d) => d}
+        start={typeof start === 'function' ? start : () => start}
+        enter={typeof enter === 'function' ? enter : () => enter}
+        update={typeof update === 'function' ? update : () => update}
+        leave={typeof leave === 'function' ? leave : () => leave}
       >
         {(inters) => {
           if (!inters.length) {

--- a/src/Animate/Animate.spec.js
+++ b/src/Animate/Animate.spec.js
@@ -18,13 +18,24 @@ const renderNode = () => (
 );
 
 describe('<Animate />', () => {
-  it('should render child Node', () => {
+  it('should render child Node with the children prop', () => {
     const wrapper = shallow(
       <Animate
         start={{}}
       >
         {renderNode}
       </Animate>,
+    );
+
+    assert.strictEqual(wrapper.find(Node).length, 1, 'should be true');
+  });
+
+  it('should render child Node with the render prop', () => {
+    const wrapper = shallow(
+      <Animate
+        start={{}}
+        render={renderNode}
+      />,
     );
 
     assert.strictEqual(wrapper.find(Node).length, 1, 'should be true');

--- a/src/NodeGroup/NodeGroup.js
+++ b/src/NodeGroup/NodeGroup.js
@@ -190,8 +190,16 @@ class NodeGroup extends Component {
   }
 
   render() {
-    const renderedChildren = this.props.children(this.state.nodes);
-    return renderedChildren && React.Children.only(renderedChildren);
+    const { render, children, Component: Comp } = this.props;
+    let rendered;
+    if (Comp) {
+      rendered = React.createElement(Comp, null, {
+        nodes: this.state.nodes,
+      });
+    } else {
+      rendered = (render || children)(this.state.nodes);
+    }
+    return rendered ? React.Children.only(rendered) : null;
   }
 }
 

--- a/src/NodeGroup/NodeGroup.js
+++ b/src/NodeGroup/NodeGroup.js
@@ -45,10 +45,6 @@ type Props = {
    * A function that renders the node. The function is passed the state.
    */
   render?: (state: {}) => {},
-  /**
-   * A function that renders the node. The function is passed the state.
-   */
-  Component?: React.Component,
 };
 
 class NodeGroup extends Component {
@@ -197,15 +193,8 @@ class NodeGroup extends Component {
   }
 
   render() {
-    const { render, children, Component: Comp } = this.props;
-    let rendered;
-    if (Comp) {
-      rendered = React.createElement(Comp, null, {
-        nodes: this.state.nodes,
-      });
-    } else {
-      rendered = (render || children)(this.state.nodes);
-    }
+    const { render, children } = this.props;
+    const rendered = (render || children)(this.state.nodes);
     return rendered ? React.Children.only(rendered) : null;
   }
 }

--- a/src/NodeGroup/NodeGroup.js
+++ b/src/NodeGroup/NodeGroup.js
@@ -18,8 +18,8 @@ type Props = {
    */
   keyAccessor: (data: {}, index: number) => string,
   /**
-  * A function that returns the starting state.  The function is passed the data and index and must return an object.
-  */
+   * A function that returns the starting state.  The function is passed the data and index and must return an object.
+   */
   start: (data: {}, index: number) => {} | Array<{}>,
   /**
    * A function that **returns an object or array of objects** describing how the state should transform on enter.  The function is passed the data and index.
@@ -34,9 +34,21 @@ type Props = {
    */
   leave?: (data: {}, index: number) => {} | Array<{}>,
   /**
+   * An optional default timing object for any interpolations happening in this component.
+   */
+  timing?: Object,
+  /**
    * A function that renders the nodes. It should accept an array of nodes as its only argument.  Each node is an object with the key, data, state and a type of 'ENTER', 'UPDATE' or 'LEAVE'.
    */
   children: (nodes: Array<{}>) => {},
+  /**
+   * A function that renders the node. The function is passed the state.
+   */
+  render?: (state: {}) => {},
+  /**
+   * A function that renders the node. The function is passed the state.
+   */
+  Component?: React.Component,
 };
 
 class NodeGroup extends Component {
@@ -48,7 +60,7 @@ class NodeGroup extends Component {
 
   state = {
     nodes: [],
-  }
+  };
 
   componentDidMount() {
     this.updateNodes(this.props);
@@ -75,7 +87,7 @@ class NodeGroup extends Component {
   props: Props;
 
   updateNodes(props) {
-    const { data, keyAccessor, start, enter, update, leave } = props;
+    const { data, keyAccessor, start, enter, update, leave, timing } = props;
 
     const currKeyIndex = {};
     const currNodeKeys = this.nodeKeys;
@@ -112,12 +124,7 @@ class NodeGroup extends Component {
       }
     }
 
-    this.nodeKeys = mergeKeys(
-      currNodeKeys,
-      currKeyIndex,
-      nextNodeKeys,
-      nextKeyIndex,
-    );
+    this.nodeKeys = mergeKeys(currNodeKeys, currKeyIndex, nextNodeKeys, nextKeyIndex);
 
     for (let i = 0; i < this.nodeKeys.length; i++) {
       const k = this.nodeKeys[i];
@@ -126,11 +133,11 @@ class NodeGroup extends Component {
 
       if (n.type === ENTER) {
         n.setState(start(d, nextKeyIndex[k]));
-        transition.call(n, enter(d, nextKeyIndex[k]));
+        transition.call(n, enter(d, nextKeyIndex[k]), timing);
       } else if (n.type === LEAVE) {
-        transition.call(n, leave(d, currKeyIndex[k]));
+        transition.call(n, leave(d, currKeyIndex[k]), timing);
       } else {
-        transition.call(n, update(d, nextKeyIndex[k]));
+        transition.call(n, update(d, nextKeyIndex[k]), timing);
       }
     }
 
@@ -174,7 +181,7 @@ class NodeGroup extends Component {
 
     this.nodeKeys = nextNodeKeys;
     this.renderNodes();
-  }
+  };
 
   nodeHash = {};
   nodeKeys = [];

--- a/src/NodeGroup/NodeGroup.spec.js
+++ b/src/NodeGroup/NodeGroup.spec.js
@@ -41,6 +41,19 @@ describe('<NodeGroup />', () => {
     assert.strictEqual(wrapper.is('g'), true, 'should be true');
   });
 
+  it('should render nodes using the render prop', () => {
+    const wrapper = shallow(
+      <NodeGroup
+        data={data}
+        keyAccessor={(d) => d.val}
+        start={() => ({})}
+        render={renderChildren}
+      />,
+    );
+
+    assert.strictEqual(wrapper.is('g'), true, 'should be true');
+  });
+
   it('should render a node for each data item', () => {
     const wrapper = mount(
       <NodeGroup

--- a/src/core/transition/transition.js
+++ b/src/core/transition/transition.js
@@ -33,7 +33,7 @@ export const preset = {
   ease: linear,
 };
 
-function scheduleTransitions(config = {}) {
+function scheduleTransitions(config = {}, defaultTiming = {}) {
   const transitions = { ...config };
 
   const events = transitions.events || {};
@@ -125,17 +125,17 @@ function scheduleTransitions(config = {}) {
       }
     }
 
-    const timingConfig = { ...preset, ...timing, time: timeNow() };
+    const timingConfig = { ...preset, ...defaultTiming, ...timing, time: timeNow() };
     schedule(this, stateKey, newId(), timingConfig, tweens, events);
   });
 }
 
-export default function transition(config) {
+export default function transition(config, defaultTiming) {
   if (Array.isArray(config)) {
     config.forEach((c) => {
-      scheduleTransitions.call(this, c);
+      scheduleTransitions.call(this, c, defaultTiming);
     });
   } else {
-    scheduleTransitions.call(this, config);
+    scheduleTransitions.call(this, config, defaultTiming);
   }
 }


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! -->

- Adds the ability to render with a `render` prop instead of the `children` prop
- Adds a `timing` prop to `Animate` and `TransitionGroup` which allows you to set the default timing object for animations at the component-level.
