### PR TITLE
Refactor soon to be deprecated lifecycle methods to run in strict mode

### DIFF
--- a/src/NodeGroup/NodeGroup.js
+++ b/src/NodeGroup/NodeGroup.js
@@ -56,7 +56,7 @@ class NodeGroup extends Component {
 
   componentDidUpdate(previous) {
     if (previous.data !== this.props.data) {
-      this.updateNodes(this.props);
+      this.updateNodes(this.props`);
     }
   }
 

--- a/src/NodeGroup/NodeGroup.js
+++ b/src/NodeGroup/NodeGroup.js
@@ -56,7 +56,7 @@ class NodeGroup extends Component {
 
   componentDidUpdate(previous) {
     if (previous.data !== this.props.data) {
-      this.updateNodes(this.props`);
+      this.updateNodes(this.props);
     }
   }
 

--- a/src/NodeGroup/NodeGroup.js
+++ b/src/NodeGroup/NodeGroup.js
@@ -54,9 +54,9 @@ class NodeGroup extends Component {
     this.updateNodes(this.props);
   }
 
-  componentWillReceiveProps(next) {
-    if (next.data !== this.props.data) {
-      this.updateNodes(next);
+  componentDidUpdate(previous) {
+    if (previous.data !== this.props.data) {
+      this.updateNodes(this.props);
     }
   }
 


### PR DESCRIPTION
I just want to start the conversation around how best to remove the soon to be deprecated lifeCycleMethods `componentWilllMount` and `componentWIllReceiveProps`.

I've made one change to `NodeGroup` but I am unfamiliar with the codebase and I am not sure what the repercussions are.

