### PR TITLE
final pass for NodeGroup

### DIFF
--- a/src/NodeGroup/index.d.ts
+++ b/src/NodeGroup/index.d.ts
@@ -1,24 +1,19 @@
-import * as React from "react";
-import {
-  Config,
-} from 'kapellmeister';
-import { GetInterpolator } from '..'
+import * as React from 'react';
+import { Config } from 'kapellmeister';
+import { GetInterpolator } from '..';
 
-export type AddArrayLike<T> = unknown extends T ? Config | Config[] : {
-  [P in keyof T]: T[P] | T[P][]
-}
+export type MakeState<T> = { [P in keyof T]: T[P] extends number | string ? T[P] | T[P][] : MakeState<T[P]> };
 
-export interface INodeGroupProps<T = unknown, State = unknown> {
+export interface INodeGroupProps<T = any, State = any> {
   data: T[];
   keyAccessor: (data: T, index: number) => string | number;
-  interpolation?: GetInterpolator;
-  start: (data: T, index: number) =>  unknown extends State ? Config : State;
-  enter?: (data: T, index: number) => AddArrayLike<State>;
-  update?: (data: T, index: number) => AddArrayLike<State>;
-  leave?: (data: T, index: number) => AddArrayLike<State>;
-  children: (nodes: T & { key: string | number, data: T, state: unknown extends State ? Config : State }[]) => React.ReactElement<any>;
+  start: (data: T, index: number) => State & Partial<Config>;
+  enter?: (data: T, index: number) => MakeState<State> & Partial<Config>;
+  update?: (data: T, index: number) => MakeState<State> & Partial<Config>;
+  leave?: (data: T, index: number) => (MakeState<State> & Partial<Config>) | undefined;
+  children: (nodes: T & { key: string | number; data: T; state: State }[]) => React.ReactElement<any>;
 }
 
-export declare class INodeGroup<T = unknown, State = unknown> extends React.Component<INodeGroupProps<T, State>> { }
+export declare class INodeGroup<T = any, State = any> extends React.Component<INodeGroupProps<T, State>> {}
 
-export default INodeGroup
+export default INodeGroup;


### PR DESCRIPTION
I'm just going to leave this here.  Delete it, bin it or you might find something useful.

The reason I started doing this is because this is what I saw in my console when I upgraded `react-move@l5.2`.

![react-move](https://user-images.githubusercontent.com/118328/53950485-292b9300-40c4-11e9-8e6b-9600dda9573c.png)

I was trying to fix these with a very limited view of the project before being told I was running round in circles etc. and not using every use case known to react-move.

I no longer see these errors for my admittedly narrow use case.

I do think the typing is broke and should be fixed but if no one else is complaining then maybe not many are using ts which is totally fine.

These types work for my use case, namespaces and all.

There won't be any more conversation but this might at least end on a somewhat useful note.

